### PR TITLE
Fixed compatibility issue in clicker

### DIFF
--- a/mpl_point_clicker/_clicker.py
+++ b/mpl_point_clicker/_clicker.py
@@ -3,6 +3,7 @@
 # Copyright (c) Ian Hunt-Isaak.
 # Distributed under the terms of the Modified BSD License.
 from __future__ import annotations
+
 __all__ = [
     "clicker",
 ]
@@ -141,7 +142,7 @@ class clicker:
             self._positions[k] = list(v)
         self._observers.process('pos-set', self.get_positions())
 
-    def clear_positions(self, classes: str | list[str] | None  = None):
+    def clear_positions(self, classes: str | list[str] | None = None):
         """
         Clear all points of classes in *classes*.
 

--- a/mpl_point_clicker/_clicker.py
+++ b/mpl_point_clicker/_clicker.py
@@ -11,7 +11,7 @@ from numbers import Integral
 import numpy as np
 from matplotlib.backend_bases import MouseButton
 from matplotlib.cbook import CallbackRegistry
-
+from typing import Union
 
 class clicker:
     def __init__(
@@ -141,7 +141,7 @@ class clicker:
             self._positions[k] = list(v)
         self._observers.process('pos-set', self.get_positions())
 
-    def clear_positions(self, classes: str | list[str] | None = None):
+    def clear_positions(self, classes: Union[str, list[str], None] = None):
         """
         Clear all points of classes in *classes*.
 

--- a/mpl_point_clicker/_clicker.py
+++ b/mpl_point_clicker/_clicker.py
@@ -2,12 +2,11 @@
 
 # Copyright (c) Ian Hunt-Isaak.
 # Distributed under the terms of the Modified BSD License.
-
+from __future__ import annotations
 __all__ = [
     "clicker",
 ]
 from numbers import Integral
-from typing import Union
 
 import numpy as np
 from matplotlib.backend_bases import MouseButton
@@ -142,7 +141,7 @@ class clicker:
             self._positions[k] = list(v)
         self._observers.process('pos-set', self.get_positions())
 
-    def clear_positions(self, classes: Union[str, list[str], None] = None):
+    def clear_positions(self, classes: str | list[str] | None  = None):
         """
         Clear all points of classes in *classes*.
 

--- a/mpl_point_clicker/_clicker.py
+++ b/mpl_point_clicker/_clicker.py
@@ -7,11 +7,12 @@ __all__ = [
     "clicker",
 ]
 from numbers import Integral
+from typing import Union
 
 import numpy as np
 from matplotlib.backend_bases import MouseButton
 from matplotlib.cbook import CallbackRegistry
-from typing import Union
+
 
 class clicker:
     def __init__(

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    --future--
     matplotlib
     numpy
 classifiers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ packages = find:
 install_requires =
     matplotlib
     numpy
+    typing
 classifiers =
     Intended Audience :: Developers
     Intended Audience :: Science/Research

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,9 @@ classifiers =
 [options]
 packages = find:
 install_requires =
+    --future--
     matplotlib
     numpy
-    __future__
 classifiers =
     Intended Audience :: Developers
     Intended Audience :: Science/Research

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ packages = find:
 install_requires =
     matplotlib
     numpy
-    typing
+    __future__
 classifiers =
     Intended Audience :: Developers
     Intended Audience :: Science/Research


### PR DESCRIPTION
_clicker used python syntax that is only compatible with python 3.10+. I changed the syntax to be compatible with earlier versions. My research group uses this open source library with python 3.9.6 and are glad to contribute.
Package now requires the typing module as a dependency.

Committer Contact info:

H. Ryott Glayzer, she/her
email: code@ryott.gay